### PR TITLE
Updated location

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 1. The name of the game is Lexinomicon.
 1. The goal of the game is to develop a healthy bounty economy for the development of Ulex.
-1. The source for the rules are kept in the [website repository](https://github.com/cryptotechguru/Lexinomicon).
-1. The rules are published on the [website](https://cryptotechguru.github.io/Lexinomicon/).
+1. The source for the rules are kept in the [website repository](https://github.com/ulex-opensource/Lexinomicon).
+1. The rules are published on the [website](https://ulex-opensource.github.io/Lexinomicon/).
 
 # Process
 


### PR DESCRIPTION
Resolves #14 (and ratifies the transfer of Lexinomicon from cryptotechguru to ulex-opensource)